### PR TITLE
Update ava dependency to version 3.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "watcher"
   ],
   "ava": {
+    "babel": true,
     "failWithoutAssertions": false,
     "verbose": true,
     "files": [
@@ -54,9 +55,10 @@
     "tiny-readdir": "^1.5.0"
   },
   "devDependencies": {
+    "@ava/babel": "^2.0.0",
     "@types/debounce": "^1.2.0",
     "@types/node": "^14.14.9",
-    "ava": "^2.4.0",
+    "ava": "^3.15.0",
     "ava-spec": "^1.1.1",
     "fs-extra": "^9.0.1",
     "lodash": "^4.17.20",


### PR DESCRIPTION
Ran `npm audit fix --force` to fix vulnerabilities which updated ava to 3.15.0. Also added @ava/babel to successfully run tests with this update