### PR TITLE
Fix deprecation warning in test

### DIFF
--- a/test/hooks.js
+++ b/test/hooks.js
@@ -17,7 +17,7 @@ let TREES = [];
 const before = async () => {
 
   if ( fs.existsSync ( Tree.ROOT ) ) {
-    fs.rmdirSync ( Tree.ROOT, { recursive: true } );
+    fs.rmSync ( Tree.ROOT, { recursive: true } );
   }
 
   TREES = await Promise.all ( Array ( 190 ).fill ().map ( async ( _, i ) => {


### PR DESCRIPTION
Fixes the following deprecation warning:

> (node:1064250) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead