### PR TITLE
fix failing Linux tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@types/node": "^20.14.9",
     "fava": "^0.3.4",
+    "fs-extra": "^11.2.0",
     "tsex": "^4.0.2",
     "typescript": "^5.5.2"
   }

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -152,11 +152,11 @@ const withContext = fn => {
 
   return async t => {
 
-    await beforeEach ( t );
+    beforeEach ( t );
 
     await fn ( t );
 
-    await afterEach ( t );
+    afterEach ( t );
 
   };
 

--- a/test/tree.js
+++ b/test/tree.js
@@ -1,8 +1,8 @@
 
 /* IMPORT */
 
-import fs from 'node:fs';
-import path, { dirname } from 'node:path';
+import fs from 'fs-extra';
+import path from 'node:path';
 import process from 'node:process';
 
 /* MAIN */
@@ -31,19 +31,18 @@ class Tree {
   }
 
   build () {
-    Tree.BLUEPRINT.forEach ( path => {
+    return Promise.all ( Tree.BLUEPRINT.map ( path => {
       if ( path.endsWith ( '/' ) ) {
-        fs.mkdirSync ( this.path ( path ), { recursive: true } );
+        return fs.ensureDir ( this.path ( path ) );
       } else {
-        fs.mkdirSync ( dirname ( this.path ( path ) ), { recursive: true } );
-        fs.writeFileSync ( this.path ( path ), '' );
+        return fs.ensureFile ( this.path ( path ) );
       }
-    });
+    }));
   }
 
   copy ( path1, path2, delay = 0 ) {
     setTimeout ( () => {
-      fs.cpSync ( this.path ( path1 ), this.path ( path2 ), { recursive: true } );
+      fs.copySync ( this.path ( path1 ), this.path ( path2 ) );
     }, delay );
   }
 
@@ -55,7 +54,7 @@ class Tree {
 
   newDir ( path, delay = 0 ) {
     setTimeout ( () => {
-      fs.mkdirSync ( this.path ( path ), { recursive: true } );
+      fs.ensureDirSync ( this.path ( path ) );
     }, delay );
   }
 
@@ -63,15 +62,14 @@ class Tree {
     return Array ( count ).fill ().map ( ( _, nr ) => {
       const id = 'newdir_' + nr;
       const dpath = this.path ( path, id );
-      fs.mkdirSync ( dpath, { recursive: true } );
+      fs.ensureDirSync ( dpath );
       return dpath;
     });
   }
 
   newFile ( path, delay = 0 ) {
     setTimeout ( () => {
-      fs.mkdirSync ( dirname ( this.path ( path ) ), { recursive: true } );
-      fs.writeFileSync ( this.path ( path ), '' );
+      fs.ensureFileSync ( this.path ( path ) );
     }, delay );
   }
 
@@ -79,8 +77,7 @@ class Tree {
     return Array ( count ).fill ().map ( ( _, nr ) => {
       const id = 'newfile_' + nr;
       const fpath = this.path ( path, id );
-      fs.mkdirSync ( dirname ( fpath ), { recursive: true } );
-      fs.writeFileSync ( fpath, '' );
+      fs.ensureFileSync ( fpath );
       return fpath;
     });
   }
@@ -95,7 +92,7 @@ class Tree {
 
   remove ( path, delay = 0 ) {
     setTimeout ( () => {
-      fs.rmSync ( this.path ( path ), { recursive: true } );
+      fs.removeSync ( this.path ( path ) );
     }, delay );
   }
 


### PR DESCRIPTION
The Linux tests passed on my machine with this PR. Some of the tests are flaky, so they don't pass consistently, but it's a nice milestone!

This adds back an extra dependency, but I think that's not too bad since it's in `devDependencies`, so won't affect users. I was able to reduce the test failures by adding back `fs-extra` in just one of the files where it was originally used. By going through the commit history and rerunning tests at various points, I've been able to see that the number of Linux tests failing has increased a couple of times since https://github.com/fabiospampinato/watcher/issues/17 was filed. It would be good to get the CI green again to prevent such regressions. Once the CI is stable we can more confidently make changes and it would be easier to another stab at removing `fs-extra` without breaking things.